### PR TITLE
feat: Quick Character Switcher Colors

### DIFF
--- a/CharacterSelectPlugin/CharacterDesign.cs
+++ b/CharacterSelectPlugin/CharacterDesign.cs
@@ -1,11 +1,14 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Numerics;
 
 namespace CharacterSelectPlugin
 {
     public class CharacterDesign
     {
+        private static int CurrentVersion = 1;
+
         public string Name { get; set; }
         public string Macro { get; set; }
         public bool IsAdvancedMode { get; set; } // Tracks if Advanced Mode was used
@@ -23,11 +26,10 @@ namespace CharacterSelectPlugin
         public Guid Id { get; set; } = Guid.NewGuid();
         public int SortOrder { get; set; } = 0;
         public Vector3 Color { get; set; } = new Vector3(1.0f, 1.0f, 1.0f); // Default to white
+        public int Version { get; set; } = CurrentVersion; // Tracks the version of the design for future compatibility
 
 
-
-
-        public CharacterDesign(string name, Vector3 color, string macro, bool isAdvancedMode = false, string advancedMacro = "", string glamourerDesign = "", string automation = "", string customizePlusProfile = "", string? previewImagePath = null)
+        public CharacterDesign(string name, Vector3 color, string macro, bool isAdvancedMode = false, string advancedMacro = "", string glamourerDesign = "", string automation = "", string customizePlusProfile = "", string? previewImagePath = null, int version = 0)
         {
             Name = name;
             Color = color;
@@ -40,6 +42,12 @@ namespace CharacterSelectPlugin
             PreviewImagePath = previewImagePath;
             DateAdded = DateTime.UtcNow;
             IsFavorite = false;  // Default to not favourited
+            
+            if (version < 1) // Version 0 -> 1 Compatibility
+            {
+                Color = new Vector3(1.0f, 1.0f, 1.0f); // Default to white
+                Version = CurrentVersion;
+            }
         }
     }
 }

--- a/CharacterSelectPlugin/CharacterDesign.cs
+++ b/CharacterSelectPlugin/CharacterDesign.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Numerics;
 
 namespace CharacterSelectPlugin
 {
@@ -21,13 +22,15 @@ namespace CharacterSelectPlugin
         public Guid? FolderId { get; set; } = null; 
         public Guid Id { get; set; } = Guid.NewGuid();
         public int SortOrder { get; set; } = 0;
+        public Vector3 Color { get; set; } = new Vector3(1.0f, 1.0f, 1.0f); // Default to white
 
 
 
 
-        public CharacterDesign(string name, string macro, bool isAdvancedMode = false, string advancedMacro = "", string glamourerDesign = "", string automation = "", string customizePlusProfile = "", string? previewImagePath = null)
+        public CharacterDesign(string name, Vector3 color, string macro, bool isAdvancedMode = false, string advancedMacro = "", string glamourerDesign = "", string automation = "", string customizePlusProfile = "", string? previewImagePath = null)
         {
             Name = name;
+            Color = color;
             Macro = macro;
             IsAdvancedMode = isAdvancedMode; // Tracks if this design was saved in Advanced Mode
             AdvancedMacro = advancedMacro;   // Stores the exact Advanced Mode macro if used

--- a/CharacterSelectPlugin/Plugin.cs
+++ b/CharacterSelectPlugin/Plugin.cs
@@ -923,6 +923,7 @@ namespace CharacterSelectPlugin
                     string defaultDesignName = $"{NewCharacterName} {NewGlamourerDesign}";
                     var defaultDesign = new CharacterDesign(
                     defaultDesignName,
+                    new Vector3(1.0f, 1.0f, 1.0f), // Default to white
                     "",  // macro will be filled below
                     false,
                     ""

--- a/CharacterSelectPlugin/QuickSwitchWindow.cs
+++ b/CharacterSelectPlugin/QuickSwitchWindow.cs
@@ -119,8 +119,12 @@ namespace CharacterSelectPlugin.Windows
             {
                 var selectedCharacter = plugin.Characters[selectedCharacterIndex];
                 int tempDesignIndex = selectedDesignIndex;
+                var selectedDesign = GetSelectedDesign(selectedCharacter);
 
                 ImGui.SetNextItemWidth(dropdownWidth);
+                var designComboColor = ImRaii.PushColor(ImGuiCol.Text, selectedDesignIndex >= 0 && selectedDesignIndex < selectedCharacter.Designs.Count && selectedDesign != null
+                    ? GetDesignColor(selectedDesign)
+                    : new Vector4(1, 1, 1, 1));
                 if (ImGui.BeginCombo("##DesignDropdown", GetSelectedDesignName(selectedCharacter), ImGuiComboFlags.HeightRegular))
                 {
                     var orderedDesigns = selectedCharacter.Designs
@@ -132,7 +136,9 @@ namespace CharacterSelectPlugin.Windows
                     {
                         var entry = orderedDesigns[j];
                         bool isSelected = (tempDesignIndex == entry.OriginalIndex);
+                        var designColor = GetDesignColor(entry.Design);
 
+                        using var color = ImRaii.PushColor(ImGuiCol.Text, designColor);
                         if (ImGui.Selectable(entry.Design.Name, isSelected))
                         {
                             tempDesignIndex = entry.OriginalIndex; // store original index to stay consistent
@@ -144,6 +150,8 @@ namespace CharacterSelectPlugin.Windows
 
                     ImGui.EndCombo();
                 }
+
+                designComboColor.Dispose();
 
                 selectedDesignIndex = tempDesignIndex;
             }
@@ -321,6 +329,11 @@ namespace CharacterSelectPlugin.Windows
             return new Vector4(character.NameplateColor.X, character.NameplateColor.Y, character.NameplateColor.Z, 1.0f);
         }
 
+        private Vector4 GetDesignColor(CharacterDesign design)
+        {
+            return new Vector4(design.Color.X, design.Color.Y, design.Color.Z, 1.0f);
+        }
+
         private string GetSelectedCharacterName()
         {
             return (selectedCharacterIndex >= 0 && selectedCharacterIndex < plugin.Characters.Count)
@@ -328,11 +341,16 @@ namespace CharacterSelectPlugin.Windows
                 : "Select Character";
         }
 
-        private string GetSelectedDesignName(Character character)
+        private CharacterDesign? GetSelectedDesign(Character character)
         {
             return (selectedDesignIndex >= 0 && selectedDesignIndex < character.Designs.Count)
-                ? character.Designs[selectedDesignIndex].Name
-                : "Select Design";
+                ? character.Designs[selectedDesignIndex]
+                : null;
+        }
+
+        private string GetSelectedDesignName(Character character)
+        {
+            return GetSelectedDesign(character)?.Name ?? "Select Design";
         }
 
         private Vector4 GetContrastingTextColor(Vector4 bgColor)

--- a/CharacterSelectPlugin/QuickSwitchWindow.cs
+++ b/CharacterSelectPlugin/QuickSwitchWindow.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Numerics;
 using Dalamud.Bindings.ImGui;
+using Dalamud.Interface.Utility.Raii;
 using Dalamud.Interface.Windowing;
 
 namespace CharacterSelectPlugin.Windows
@@ -71,6 +72,9 @@ namespace CharacterSelectPlugin.Windows
             ImGui.SetNextItemWidth(dropdownWidth);
             int tempCharacterIndex = selectedCharacterIndex;
 
+            var characterComboColor = ImRaii.PushColor(ImGuiCol.Text, selectedCharacterIndex >= 0 && selectedCharacterIndex < plugin.Characters.Count
+                ? GetNameplateColor(plugin.Characters[selectedCharacterIndex])
+                : new Vector4(1, 1, 1, 1));
             if (ImGui.BeginCombo("##CharacterDropdown", GetSelectedCharacterName(), ImGuiComboFlags.HeightRegular))
             {
                 for (int i = 0; i < plugin.Characters.Count; i++)
@@ -78,6 +82,7 @@ namespace CharacterSelectPlugin.Windows
                     var character = plugin.Characters[i];
                     bool isSelected = (tempCharacterIndex == i);
 
+                    using var color = ImRaii.PushColor(ImGuiCol.Text, GetNameplateColor(character));
                     if (ImGui.Selectable(character.Name, isSelected))
                     {
                         tempCharacterIndex = i;
@@ -102,6 +107,8 @@ namespace CharacterSelectPlugin.Windows
                 }
                 ImGui.EndCombo();
             }
+
+            characterComboColor.Dispose();
 
             selectedCharacterIndex = tempCharacterIndex;
 

--- a/CharacterSelectPlugin/Windows/Components/DesignPanel.cs
+++ b/CharacterSelectPlugin/Windows/Components/DesignPanel.cs
@@ -38,6 +38,7 @@ namespace CharacterSelectPlugin.Windows.Components
 
         // Edit fields
         private string editedDesignName = "";
+        private Vector3 editedDesignColor = new Vector3(1.0f, 1.0f, 1.0f);
         private string editedDesignMacro = "";
         private string editedGlamourerDesign = "";
         private string editedAutomation = "";
@@ -517,6 +518,11 @@ namespace CharacterSelectPlugin.Windows.Components
             }
             plugin.DesignNameFieldPos = ImGui.GetItemRectMin();
             plugin.DesignNameFieldSize = ImGui.GetItemRectSize();
+
+            // Design Color
+            ImGui.Text("Design Color");
+            ImGui.SetCursorPosX(10 * scale);
+            ImGui.ColorEdit3("##DesignColor", ref editedDesignColor);
 
             ImGui.Separator();
 
@@ -1177,7 +1183,7 @@ namespace CharacterSelectPlugin.Windows.Components
                 name = TruncateWithEllipsis(name, availW);
 
             // Design name
-            ImGui.PushStyleColor(ImGuiCol.Text, new Vector4(0.9f, 0.9f, 0.9f, 1f));
+            ImGui.PushStyleColor(ImGuiCol.Text, new Vector4(design.Color.X, design.Color.Y, design.Color.Z, 1f));
             ImGui.TextUnformatted(name);
             ImGui.PopStyleColor();
 
@@ -1345,6 +1351,7 @@ namespace CharacterSelectPlugin.Windows.Components
                             {
                                 var clone = new CharacterDesign(
                                     name: $"{design.Name} (Copy)",
+                                    color: design.Color,
                                     macro: design.Macro,
                                     isAdvancedMode: design.IsAdvancedMode,
                                     advancedMacro: design.AdvancedMacro,
@@ -1477,6 +1484,7 @@ namespace CharacterSelectPlugin.Windows.Components
             isEditDesignWindowOpen = true;
             plugin.IsEditDesignWindowOpen = true;
             editedDesignName = "";
+            editedDesignColor = new Vector3(1.0f, 1.0f, 1.0f);
             editedGlamourerDesign = "";
             editedDesignMacro = "";
             isAdvancedModeDesign = false;
@@ -1494,6 +1502,7 @@ namespace CharacterSelectPlugin.Windows.Components
             plugin.IsEditDesignWindowOpen = true;
             originalDesignName = design.Name;
             editedDesignName = design.Name;
+            editedDesignColor = design.Color;
             editedDesignMacro = design.IsAdvancedMode ? design.AdvancedMacro ?? "" : design.Macro ?? "";
             editedGlamourerDesign = !string.IsNullOrWhiteSpace(design.GlamourerDesign)
                 ? design.GlamourerDesign
@@ -1520,6 +1529,7 @@ namespace CharacterSelectPlugin.Windows.Components
         private void ResetEditFields()
         {
             editedDesignName = "";
+            editedDesignColor = new Vector3(1.0f, 1.0f, 1.0f);
             editedDesignMacro = "";
             editedGlamourerDesign = "";
             editedAutomation = "";
@@ -1542,6 +1552,7 @@ namespace CharacterSelectPlugin.Windows.Components
             {
                 // Update existing design
                 existingDesign.Name = editedDesignName;
+                existingDesign.Color = editedDesignColor;
                 bool wasPreviouslyAdvanced = existingDesign.IsAdvancedMode;
                 bool keepAdvanced = wasPreviouslyAdvanced && !isAdvancedModeDesign;
 
@@ -1564,6 +1575,7 @@ namespace CharacterSelectPlugin.Windows.Components
                 // Add new design
                 character.Designs.Add(new CharacterDesign(
                     editedDesignName,
+                    editedDesignColor,
                     isAdvancedModeDesign ? advancedDesignMacroText : GenerateDesignMacro(character),
                     isAdvancedModeDesign,
                     isAdvancedModeDesign ? advancedDesignMacroText : "",


### PR DESCRIPTION
This introduces colors in the Quick Character Switch. For Characters, it uses the already existing `NameplateColor` field. For Designs, a newly introduced `Color` field can be set.

Alongside this, I also added Versioning inside of the `CharacterDesign` class to handle the adding of the new `Color` field.

<img width="366" height="226" alt="image" src="https://github.com/user-attachments/assets/47d0e049-f621-44a9-beac-b5e017cd0594" />